### PR TITLE
[BUGFIX] Add dependency to EXT:impexp

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,8 @@ $EM_CONF[$_EXTKEY] = array(
 	'constraints' => array(
 		'depends' => array(
 			'typo3' => '10.0.0-10.4.99',
-			'bootstrap_package' => '11.0.0-11.5.99'
+			'bootstrap_package' => '11.0.0-11.5.99',
+			'impexp' => '10.0.0-10.4.99'
 		),
 		'conflicts' => array(),
 		'suggests' => array(),


### PR DESCRIPTION
The dependency to EXT:impexp has to be added to ext_emconf.php file. Otherwise the import of form definitions will fail as the `beforeAddSysFileRecordOnImport` hook is not called in ext_localconf.php of EXT:form.

Resolves: #28