### PR TITLE
[BUGFIX] Error handling configuration

### DIFF
--- a/Classes/EventListener/AfterExtensionSiteFilesHaveBeenImportedEventListener.php
+++ b/Classes/EventListener/AfterExtensionSiteFilesHaveBeenImportedEventListener.php
@@ -62,7 +62,7 @@ final class AfterExtensionSiteFilesHaveBeenImportedEventListener
     {
         // Remove existing configuration
         $configuration['errorHandling'] = array_filter(
-            $configuration['errorHandling'],
+            $configuration['errorHandling'] ?? [],
             fn ($errorHandler) => ($errorHandler['errorCode'] ?? null) !== 404
         );
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"ext-pdo": "*",
 		"bk2k/bootstrap-package": "^12.0.2",
 		"typo3/cms-core": "^10.4.10",
+		"typo3/cms-extensionmanager": "^10.4.10",
 		"typo3/cms-felogin": "^10.4.10",
 		"typo3/cms-filemetadata": "^10.4.10",
 		"typo3/cms-form": "^10.4.10",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,6 +26,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '10.4.10-10.4.99',
             'bootstrap_package' => '11.0.3-11.0.99',
+            'extensionmanager' => '10.4.10-10.4.99',
             'felogin' => '10.4.10-10.4.99',
             'filemetadata' => '10.4.10-10.4.99',
             'form' => '10.4.10-10.4.99',


### PR DESCRIPTION
Fixes a bug if no error handling configuration is available and adds the
missing dependency to ext:extensionmanager.