### PR TITLE
[BUGFIX] Cast page uid for error handler to int

### DIFF
--- a/Classes/EventListener/AfterExtensionSiteFilesHaveBeenImportedEventListener.php
+++ b/Classes/EventListener/AfterExtensionSiteFilesHaveBeenImportedEventListener.php
@@ -105,7 +105,7 @@ final class AfterExtensionSiteFilesHaveBeenImportedEventListener
         ;
 
         if (($page = $result->fetchAssociative()) !== false) {
-            return $page['uid'];
+            return (int)$page['uid'];
         }
 
         throw new \RuntimeException(\sprintf(


### PR DESCRIPTION
With sqlite it may happen that the page loaded from the database is returned as a string, while the method `getNotFoundErrorPageUid` expects an integer. To circumvent this, the uid is cast to int.